### PR TITLE
Fix workspace hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ Refer to the [Hyprland wiki](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Mana
 To configure Hyprhook, specify the script directories for each event in your Hyprland configuration file. When an event occurs, the corresponding script will be executed with the event data passed as a JSON parameter (if applicable). The available keywords are the names of the events as listed in <a href="#json-parameters">JSON Parameters</a>.
 
 > [!IMPORTANT]
-> The event 'submap' is called 'onSubmap' in the configuration file.
+> Some events have a different name in the hyprhook config:
+>
+> |Event|Hyprhook config name|
+> |---|------------------|
+> |submap|onSubmap|
+> |workspace|onWorkspace|
 
 Example configuration snippet:
 
@@ -92,6 +97,7 @@ plugin {
   hyprhook {
     activeWindow = /path/to/your/script.sh
     openWindow = /path/to/another/script.sh # Add more event-script mappings as needed
+    onWorkspace = /path/to/your/workspace/script.sh # Use the right config name
   }
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744289235,
-        "narHash": "sha256-ZFkHLdimtFzQACsVVyZkZlfYdj4iNy3PkzXfrwmlse8=",
+        "lastModified": 1745357003,
+        "narHash": "sha256-jYwzQkv1r7HN/4qrAuKp+NR4YYNp2xDrOX5O9YVqkWo=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "c8282f4982b56dfa5e9b9f659809da93f8d37e7a",
+        "rev": "a19cf76ee1a15c1c12083fa372747ce46387289f",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742215578,
-        "narHash": "sha256-zfs71PXVVPEe56WEyNi2TJQPs0wabU4WAlq0XV7GcdE=",
+        "lastModified": 1745948457,
+        "narHash": "sha256-lzTV10FJTCGNtMdgW5YAhCAqezeAzKOd/97HbQK8GTU=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "2fd36421c21aa87e2fe3bee11067540ae612f719",
+        "rev": "ac903e80b33ba6a88df83d02232483d99f327573",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1745756886,
-        "narHash": "sha256-i8g/mbrzmB+Xo1Od0I5trqY6TNwiXT4BVBpmFYcVOAU=",
+        "lastModified": 1747301504,
+        "narHash": "sha256-N7eVRonAZ7N7SOl/4jMnqj7Cr/XDUI36mr9w/tKWy4A=",
         "ref": "refs/heads/main",
-        "rev": "0302bfdc2207f9b5482fb07aa6052e7f6cb237ca",
-        "revCount": 6031,
+        "rev": "a5c9b3e49047b4f03f79c5146d8925363eab3072",
+        "revCount": 6114,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -240,11 +240,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739048983,
-        "narHash": "sha256-REhTcXq4qs3B3cCDtLlYDz0GZvmsBSh947Ub6pQWGTQ=",
+        "lastModified": 1745951494,
+        "narHash": "sha256-2dModE32doiyQMmd6EDAQeZnz+5LOs6KXyE0qX76WIg=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "3504a293c8f8db4127cb0f7cfc1a318ffb4316f8",
+        "rev": "4be1d324faf8d6e82c2be9f8510d299984dfdd2e",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744468525,
-        "narHash": "sha256-9HySx+EtsbbKlZDlY+naqqOV679VdxP6x6fP3wxDXJk=",
+        "lastModified": 1746655412,
+        "narHash": "sha256-kVQ0bHVtX6baYxRWWIh4u3LNJZb9Zcm2xBeDPOGz5BY=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f1000c54d266e6e4e9d646df0774fac5b8a652df",
+        "rev": "557241780c179cf7ef224df392f8e67dab6cef83",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743950287,
-        "narHash": "sha256-/6IAEWyb8gC/NKZElxiHChkouiUOrVYNq9YqG0Pzm4Y=",
+        "lastModified": 1746635225,
+        "narHash": "sha256-W9G9bb0zRYDBRseHbVez0J8qVpD5QbizX67H/vsudhM=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "f2dc70e448b994cef627a157ee340135bd68fbc6",
+        "rev": "674ea57373f08b7609ce93baff131117a0dfe70d",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1746537231,
+        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
         "type": "github"
       },
       "original": {
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744644585,
-        "narHash": "sha256-p0D/e4J6Sv6GSb+9u8OQcVHSE2gPNYB5ygIfGDyEiXQ=",
+        "lastModified": 1745871725,
+        "narHash": "sha256-M24SNc2flblWGXFkGQfqSlEOzAGZnMc9QG3GH4K/KbE=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "be6771e754345f18244fb00aae5c9e5ab21ccc26",
+        "rev": "76bbf1a6b1378e4ab5230bad00ad04bc287c969e",
         "type": "github"
       },
       "original": {

--- a/hyprhook/src/globals.hpp
+++ b/hyprhook/src/globals.hpp
@@ -30,7 +30,7 @@ namespace Global {
         {"destroyWorkspace", Parser::parseCWorkspace},
         {"fullscreen", Parser::parseWindow},
         {"changeFloatingMode", Parser::parseWindow},
-        {"workspace", Parser::parseCWorkspace},
+        {"workspace", Parser::parseWorkspace},
         {"submap", Parser::parseSubmap},
         {"mouseMove", Parser::parseVector2D},
         {"mouseButton", Parser::parseSButtonEvent},

--- a/hyprhook/src/globals.hpp
+++ b/hyprhook/src/globals.hpp
@@ -26,8 +26,8 @@ namespace Global {
         {"minimize", Parser::parseEmpty}, //std::vectorstd::any{PHLWINDOW, int64_t}
         {"monitorAdded", Parser::parseMonitor},
         {"monitorRemoved", Parser::parseMonitor},
-        {"createWorkspace", Parser::parseCWorkspace},
-        {"destroyWorkspace", Parser::parseCWorkspace},
+        {"createWorkspace", Parser::parseWorkspace},
+        {"destroyWorkspace", Parser::parseWorkspace},
         {"fullscreen", Parser::parseWindow},
         {"changeFloatingMode", Parser::parseWindow},
         {"workspace", Parser::parseWorkspace},

--- a/hyprhook/src/main.cpp
+++ b/hyprhook/src/main.cpp
@@ -57,13 +57,20 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                 return;
             }
             const auto& it = Global::functionsMap.find(event);
+
             if (it == Global::functionsMap.end()) {
                 return;
             }
 
-            const std::string& script   = *Global::eventMap[event];
-            const std::string& spawnStr = script + " '" + it->second(data) + "'";
-            g_pKeybindManager->spawn(spawnStr);
+            const std::string& script = *Global::eventMap[event];
+
+            try {
+                const std::string& spawnStr = script + " '" + it->second(data) + "'";
+                g_pKeybindManager->spawn(spawnStr);
+            } catch (const std::bad_any_cast&) {
+                HyprlandAPI::addNotification(Global::PHANDLE, std::format("[{}] Bad any cast for '{}'. The HyprlandAPI might have changed", Global::pluginName, event), errorColor,
+                                             5000);
+            }
         });
     }
 

--- a/hyprhook/src/main.cpp
+++ b/hyprhook/src/main.cpp
@@ -39,6 +39,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
             Global::eventMap[event] =
                 (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(Global::PHANDLE, std::format("plugin:{}:onSubmap", Global::configPName))->getDataStaticPtr();
 
+        } else if (event == "workspace") {
+            HyprlandAPI::addConfigValue(Global::PHANDLE, std::format("plugin:{}:onWorkspace", Global::configPName), Hyprlang::STRING{""});
+            Global::eventMap[event] =
+                (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(Global::PHANDLE, std::format("plugin:{}:onWorkspace", Global::configPName))->getDataStaticPtr();
+
         } else {
             HyprlandAPI::addConfigValue(Global::PHANDLE, std::format("plugin:{}:{}", Global::configPName, event), Hyprlang::STRING{""});
             Global::eventMap[event] =
@@ -47,6 +52,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
         Global::enabledMap[event] = !static_cast<std::string>(*Global::eventMap[event]).empty();
 
         Global::hookMap[event] = HyprlandAPI::registerCallbackDynamic(Global::PHANDLE, event, [&](void* self, SCallbackInfo& info, std::any data) {
+            const CHyprColor errorColor(1.0f, 0.0f, 0.0f, 1.0f);
             if (!Global::enabledMap[event]) {
                 return;
             }

--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -18,6 +18,10 @@ commit_pins = [
     "5ee35f914f921e5696030698e74fb5566a804768", # hyprland v.0.48
     "cb08b5ca89d81c5497c8fba1a438d435786462f6", # hyprhook
   ],
+  [
+    "9958d297641b5c84dcff93f9039d80a5ad37ab00", # hyprland v.0.49
+    "b65edf5382d657ee1fca18c63d315016a8f599b3",
+  ],
 ]
 
 [Hyprhook]


### PR DESCRIPTION
This PR fixes the workspace hook.
The problem was similar to submap. In both cases, the token is already taken for Hyperland-specific configuration, so we have to use a different keyword in Hyperhook's config.
Like submap, I chose `onWorkspace`

This PR also includes a fix so that failed casts will trigger a notification. This will help by identifying issues when the API changes again.

This will fix #13 