### PR TITLE
Remove submodule hyprland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.lo
 *.o
 *.obj
-
 # Precompiled Headers
 *.gch
 *.pch
@@ -46,3 +45,7 @@ meson-private
 
 # vscode
 .vscode
+
+
+# Hyprland folder
+Hyprland


### PR DESCRIPTION
Remove the unneeded Hyprland submodule and add the folder to the `.gitignore` so this won't happen again.





(this is just me trying out auto generated copilot description don't mind me (it is wrong))
This pull request updates the `Hyprland` submodule to remove the specific commit reference. This change likely prepares the repository for either a new submodule update or a different configuration.