### PR TITLE
add ready guard to to prevent startup interference due to monitors

### DIFF
--- a/hyprhook/src/globals.hpp
+++ b/hyprhook/src/globals.hpp
@@ -8,6 +8,7 @@ namespace Global {
     inline HANDLE                                                         PHANDLE     = nullptr;
     const std::string                                                     pluginName  = "Hyprhook";
     const std::string                                                     configPName = "hyprhook";
+    inline bool                                                           hyprlandReady = false;
     std::unordered_map<std::string, Hyprlang::STRING const*>              eventMap;
     std::unordered_map<std::string, bool>                                 enabledMap;
     std::unordered_map<std::string, std::function<std::string(std::any)>> functionsMap = {

--- a/hyprhook/src/main.cpp
+++ b/hyprhook/src/main.cpp
@@ -22,6 +22,9 @@ static void onConfigReloaded() {
 
 template <typename T>
 static void executeHook(const std::string& event, T data) {
+    if (!Global::hyprlandReady) {
+        return;
+    }
     const CHyprColor errorColor(1.0f, 0.0f, 0.0f, 1.0f);
     if (!Global::enabledMap[event]) {
         return;
@@ -44,6 +47,9 @@ static void executeHook(const std::string& event, T data) {
 }
 
 static void executeHookEmpty(const std::string& event) {
+    if (!Global::hyprlandReady) {
+        return;
+    }
     const CHyprColor errorColor(1.0f, 0.0f, 0.0f, 1.0f);
     if (!Global::enabledMap[event]) {
         return;
@@ -96,6 +102,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     }
 
     // Register event listeners using Event::bus()
+    // Wait for Hyprland to be fully ready before executing hooks
+    static auto ready = Event::bus()->m_events.ready.listen([]() {
+        Global::hyprlandReady = true;
+    });
+
     static auto activeWindow = Event::bus()->m_events.window.active.listen([](PHLWINDOW window, Desktop::eFocusReason reason) {
         executeHook("activeWindow", window);
     });

--- a/hyprhook/src/main.cpp
+++ b/hyprhook/src/main.cpp
@@ -6,6 +6,7 @@
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/Compositor.hpp>
 
 #include "globals.hpp"
 
@@ -102,10 +103,16 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     }
 
     // Register event listeners using Event::bus()
-    // Wait for Hyprland to be fully ready before executing hooks
+    // Listen for the ready event to know when Hyprland is fully initialized
     static auto ready = Event::bus()->m_events.ready.listen([]() {
         Global::hyprlandReady = true;
     });
+    
+    // If there are already monitors (meaning we're past initialization), mark as ready immediately
+    // This handles the case where the plugin is loaded dynamically after Hyprland has started
+    if (g_pCompositor && !g_pCompositor->m_monitors.empty()) {
+        Global::hyprlandReady = true;
+    }
 
     static auto activeWindow = Event::bus()->m_events.window.active.listen([](PHLWINDOW window, Desktop::eFocusReason reason) {
         executeHook("activeWindow", window);


### PR DESCRIPTION
I noticed the my GTK applications that were ran by `exec-once` in my hypr.conf would hang due to the plugin. This adds a ready guard to prevent that and enables dynamic loading